### PR TITLE
Fix scene creation flow

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,10 @@
 <template>
     <div id="app">
-      <Sidebar :scenes="state.games[state.games.findIndex(game => game.id === state.selectedGameId)].scenes" @create="createScene" @addScript="addScript"/>
+      <Sidebar
+        :scenes="state.games[state.games.findIndex(game => game.id === state.selectedGameId)].scenes"
+        @addScene="addScene"
+        @addScript="addScript"
+      />
       <Main/>
       <ModalWindow v-if="createScriptModalOpened" :header="'Создать сценарий'" @closeModal="setCreateScriptModalState" @validate-request="saveScript"><CreateScriptModal ref="child"/></ModalWindow>
       <ModalWindow v-if="createSceneModalOpened" :header="'Создать сцену'" @closeModal="setCreateSceneModalState" @validate-request="saveScene"><CreateSceneModal ref="sceneChild"/></ModalWindow>
@@ -63,7 +67,8 @@
         this.createScriptSceneId = scene;
       },
       addScene() {
-        this.setCreateScriptModalState(true);
+        this.setCreateSceneModalState(true);
+        this.createSceneGameId = state.selectedGameId;
       },
       saveScript() {
         if(this.$refs.child.validate()) {
@@ -89,27 +94,16 @@
         }
       },
       saveScene() {
-        if (this.$refs.sceneChild.validate()) {
-          let child = this.$refs.child;
-          let game = state.games[state.games.findIndex(game => game.id === this.createScriptGameId)];
-          let scenes = game.scenes;
-          scenes[scenes.findIndex(gameId => gameId === this.createScriptSceneId)].scripts.push({
-            id: Date.now(),
-            name: child.name,
-            answersCount: child.answers_count,
-            branchesCount: child.branches_count,
-            character: {},
-            description: child.description,
-            getsItem: child.itemData.gets,
-            itemName: child.itemData.name,
-            itemCondition: child.itemData.condition,
-            getsInfo: child.infoData.gets,
-            infoName: child.infoData.name,
-            infoCondition: child.infoData.condition,
-            additional: child.additional
+        const game = state.games.find(game => game.id === this.createSceneGameId);
+        if (game) {
+          game.scenes.push({
+            id: Date.now().toString(),
+            name: `Scene ${game.scenes.length + 1}`,
+            scripts: [],
+            characters: [],
           });
-          this.setCreateScriptModalState(false);
         }
+        this.setCreateSceneModalState(false);
       }
     },
     data() {
@@ -120,6 +114,7 @@
         createScriptModalOpened: false,
         createSceneModalOpened: true,
         createScriptGameId: null,
+        createSceneGameId: null,
         scenes: []
       };
     },

--- a/src/components/Scenes.vue
+++ b/src/components/Scenes.vue
@@ -1,28 +1,22 @@
 ﻿<template>
   <div id="scenes">
-    <SceneItem v-for="scene of scenes" :scene="scene" @addScript="addScript" />
+    <SceneItem v-for="scene of scenes" :key="scene.id" :scene="scene" @addScript="addScript" />
   </div>
 </template>
 
-<style scoped>
-
-</style>
-
 <script>
-import SceneItem from "@/components/SceneItem.vue";
-import Sidebar from "@/components/Sidebar.vue";
+import SceneItem from '@/components/SceneItem.vue'
 
 export default {
   name: 'Scenes',
   props: ['scenes'],
   components: {
-    Sidebar,
-    SceneItem
+    SceneItem,
   },
   methods: {
     addScript(scene) {
-      this.$emit('addScript', scene);
-    }
-  }
+      this.$emit('addScript', scene)
+    },
+  },
 }
 </script>

--- a/src/types.js
+++ b/src/types.js
@@ -1,39 +1,38 @@
-﻿// Character
-const character = {
-    id: '',       // string
-    name: '',     // string
-  }
-  
-  // Script
-  const script = {
-    id: '',                // string
-    name: '',              // string
-    answersCount: 0,       // number (или BigInt, если хочешь)
-    branchesCount: 0,      // number (или BigInt)
-    character: character,  // объект Character
-    description: '',       // string
-    getsItem: false,       // boolean
-    itemName: '',          // string
-    itemCondition: '',     // string
-    getsInfo: false,       // boolean
-    infoName: '',          // string
-    infoCondition: '',     // string
-    additional: '',        // string
-  }
-  
-  // Scene
-  const scene = {
-    id: '',                 // string
-    name: '',               // string
-    scripts: [script],      // массив Script
-    characters: [character] // массив Character
-  }
-  
-  // Game
-  const game = {
-    id: '',                 // string
-    name: '',               // string
-    scenes: [scene],        // массив Scene
-    characters: [character] // массив Character
-  }
-  
+// Character
+export const character = {
+  id: '', // string
+  name: '', // string
+}
+
+// Script
+export const script = {
+  id: '', // string
+  name: '', // string
+  answersCount: 0, // number (или BigInt, если хочешь)
+  branchesCount: 0, // number (или BigInt)
+  character: character, // объект Character
+  description: '', // string
+  getsItem: false, // boolean
+  itemName: '', // string
+  itemCondition: '', // string
+  getsInfo: false, // boolean
+  infoName: '', // string
+  infoCondition: '', // string
+  additional: '', // string
+}
+
+// Scene
+export const scene = {
+  id: '', // string
+  name: '', // string
+  scripts: [script], // массив Script
+  characters: [character], // массив Character
+}
+
+// Game
+export const game = {
+  id: '', // string
+  name: '', // string
+  scenes: [scene], // массив Scene
+  characters: [character], // массив Character
+}


### PR DESCRIPTION
## Summary
- add missing `key` when rendering scene list
- link sidebar scene creation to modal opening
- implement simple scene creation logic

## Testing
- `npm run build`
- `npm exec vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_6870258399b083309a86b9ac5f288264