### PR TITLE
Add user profile editing

### DIFF
--- a/src/components/Games/GamesPage.vue
+++ b/src/components/Games/GamesPage.vue
@@ -2,10 +2,10 @@
   <div class="games-dashboard">
     <!-- Top bar -->
     <header class="dashboard-header">
-      <div class="dashboard-user">
-        <img class="user-avatar" src="/assets/logo.png" alt="avatar" />
-        <span class="user-name">username</span>
-      </div>
+      <router-link to="/profile" class="dashboard-user">
+        <img class="user-avatar" :src="state.user.avatar || '/assets/logo.png'" alt="avatar" />
+        <span class="user-name">{{ state.user.firstName || 'username' }}</span>
+      </router-link>
       <div class="dashboard-status">
         Всего игр: <b>{{ state.games.length }}</b>
       </div>
@@ -240,6 +240,7 @@ export default {
   display: flex;
   align-items: center;
   gap: 12px;
+  text-decoration: none;
 }
 .user-avatar {
   width: 36px;

--- a/src/components/UserProfilePage.vue
+++ b/src/components/UserProfilePage.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="auth-page">
+    <div class="auth-container">
+      <h1>Профиль</h1>
+      <form @submit.prevent="save">
+        <div class="avatar-group">
+          <img v-if="avatarPreview" :src="avatarPreview" class="avatar" />
+          <input type="file" accept="image/*" @change="onFileChange" />
+        </div>
+        <div class="form-group">
+          <input v-model="firstName" class="input" placeholder="Имя" />
+        </div>
+        <div class="form-group">
+          <input v-model="lastName" class="input" placeholder="Фамилия" />
+        </div>
+        <div class="form-group">
+          <input v-model="email" class="input" type="email" placeholder="Email" />
+        </div>
+        <button type="submit" class="btn">Сохранить</button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import { state, updateUser } from '@/store'
+export default {
+  name: 'UserProfilePage',
+  data() {
+    return {
+      firstName: state.user.firstName,
+      lastName: state.user.lastName,
+      email: state.user.email,
+      avatar: state.user.avatar,
+      avatarPreview: state.user.avatar,
+    }
+  },
+  methods: {
+    onFileChange(e) {
+      const file = e.target.files[0]
+      if (!file) return
+      const reader = new FileReader()
+      reader.onload = ev => {
+        this.avatar = ev.target.result
+        this.avatarPreview = ev.target.result
+      }
+      reader.readAsDataURL(file)
+    },
+    save() {
+      updateUser({
+        firstName: this.firstName,
+        lastName: this.lastName,
+        email: this.email,
+        avatar: this.avatar,
+      })
+      this.$router.push('/')
+    },
+  },
+}
+</script>
+
+<style scoped>
+.auth-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  width: 100%;
+  background: #f3f4f6;
+}
+.auth-container {
+  background: white;
+  padding: 2rem 3rem;
+  border-radius: 12px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  text-align: center;
+}
+.avatar-group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+.avatar {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 50%;
+  margin-bottom: 0.5rem;
+}
+.form-group {
+  margin-bottom: 1rem;
+}
+.input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.3s;
+}
+.input:focus {
+  border-color: #2563eb;
+}
+.btn {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: #2563eb;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+  transition: background-color 0.3s;
+}
+.btn:hover {
+  background-color: #1d4ed8;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,12 +3,14 @@ import EditGamePage from '@/components/EditGamePage.vue'
 import GamesPage from '@/components/Games/GamesPage.vue'
 import LoginPage from '@/components/LoginPage.vue'
 import RegisterPage from '@/components/RegisterPage.vue'
+import UserProfilePage from '@/components/UserProfilePage.vue'
 
 const routes = [
   { path: '/', name: 'main', component: GamesPage },
   { path: '/:id', name: 'edit', component: EditGamePage, params: true },
   { path: '/login', name: 'login', component: LoginPage },
-  { path: '/register', name: 'register', component: RegisterPage }
+  { path: '/register', name: 'register', component: RegisterPage },
+  { path: '/profile', name: 'profile', component: UserProfilePage },
 ]
 
 const router = createRouter({

--- a/src/store.js
+++ b/src/store.js
@@ -7,6 +7,12 @@ const defaultState = {
   selectedSceneId: null,
   selectedScriptId: null,
   token: null,
+  user: {
+    firstName: '',
+    lastName: '',
+    email: '',
+    avatar: '',
+  },
 }
 
 function load() {
@@ -14,7 +20,11 @@ function load() {
   if (raw) {
     try {
       const parsed = JSON.parse(raw)
-      return { ...defaultState, ...parsed }
+      return {
+        ...defaultState,
+        ...parsed,
+        user: { ...defaultState.user, ...(parsed.user || {}) },
+      }
     } catch (e) {
       console.error('failed to parse state', e)
     }
@@ -37,4 +47,9 @@ function clearToken() {
   saveState()
 }
 
-export { state, defaultState, saveState, setToken, clearToken }
+function updateUser(data) {
+  state.user = { ...state.user, ...data }
+  saveState()
+}
+
+export { state, defaultState, saveState, setToken, clearToken, updateUser }


### PR DESCRIPTION
## Summary
- store user info (name, email, avatar) in the Vue store
- new `UserProfilePage` component for editing profile data
- show profile info in Games page header with link to profile
- add `/profile` route

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6879070e67088330abcbdf303f7a28fa